### PR TITLE
enabled configuration ouside from config()

### DIFF
--- a/src/angular-wamp.js
+++ b/src/angular-wamp.js
@@ -221,19 +221,41 @@
                 };
             }
 
-            options = angular.extend({onchallenge: digestWrapper(onchallenge), use_deferred: $q.defer}, options);
+          /**
+           *
+           * @param connectionOptions
+           * Required options:
+           *
+           *    - `url`: `{string=}` - the WebSocket URL of the WAMP router to connect to, e.g. ws://myserver.com:8080/ws
+           *    - `realm`: `{string=}` - The WAMP realm to join, e.g. realm1
+           * @returns {*|Connection|q} the connection object
+           *
+           * @description
+           * Create the autobahn connection object.
+           *
+           */
+            function connect(connectionOptions) {
+              options = angular.extend({onchallenge: digestWrapper(onchallenge), use_deferred: $q.defer}, connectionOptions);
 
-            connection = new autobahn.Connection(options);
-            connection.onopen = digestWrapper(function (session, details) {
+              connection = new autobahn.Connection(options);
+              connection.onopen = digestWrapper(function (session, details) {
                 $log.debug("Congrats!  You're connected to the WAMP server!");
                 $rootScope.$broadcast("$wamp.open", {session: session, details: details});
                 sessionDeferred.resolve();
-            });
+              });
 
-            connection.onclose = digestWrapper(function (reason, details) {
+              connection.onclose = digestWrapper(function (reason, details) {
                 $log.debug("Connection Closed: ", reason, details);
                 $rootScope.$broadcast("$wamp.close", {reason: reason, details: details});
-            });
+              });
+
+              return connection;
+            }
+
+            if (options.url != undefined && options.realm != undefined) {
+              alert("qui");
+              connection = connect(options);
+            }
 
 
             /**
@@ -346,6 +368,9 @@
 
             return {
                 connection: connection,
+                connect: function (connectionOptions) {
+                  connect(connectionOptions);
+                },
                 open: function () {
                     //If using WAMP CRA we need to get the authid before the connection can be opened.
                     if (options.authmethods && options.authmethods.indexOf('wampcra') !== -1 && !options.authid) {


### PR DESCRIPTION
I modified a little your code in order to be able of set the url and realm of the wamp router at run time instead of config time.
I needed this modification because I used the lib in an application installed in a raspberry connected to a local network and so I can't embed the ip at the config time.
I tested my solution and is working fine for me.

With this code you can use services to setup the system, this is an example of the code:

```Javascript
app.config(function ($wampProvider) {
     $wampProvider.init();
 })
```


```Javascript
    .run(function($wamp){
       $wamp.connect({
           url: 'ws://127.0.0.1:9000/',
           realm: 'realm1'
           });
       $wamp.open();
    })
```

Maybe connect() function can be ranamed in a better way, I'm not good in choosing names :)

Thank you for attention
Simone
