### PR TITLE
Add some dev dependencies to prevent errors in use with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "angular": "^1.3.0",
-    "autobahn": "0.9.9"
+    "autobahn": "0.9.9",
     "utf-8-validate": "^1.2.1",
     "bufferutil": "^1.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "angular": "^1.3.0",
     "autobahn": "0.9.9"
+    "utf-8-validate": "^1.2.1",
+    "bufferutil": "^1.2.1"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
   },
   "dependencies": {
     "angular": "^1.3.0",
-    "autobahn": "0.9.9",
-    "utf-8-validate": "^1.2.1",
-    "bufferutil": "^1.2.1"
+    "autobahn": "0.9.9"
   },
   "license": "MIT",
   "devDependencies": {
@@ -42,6 +40,8 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-ng-annotate": "^1.0.1",
-    "load-grunt-tasks": "^3.2.0"
+    "load-grunt-tasks": "^3.2.0",
+    "utf-8-validate": "^1.2.1",
+    "bufferutil": "^1.2.1"
   }
 }


### PR DESCRIPTION
Added `utf-8-validate`and `bufferutil` dev dependencies to prevent module not found errors when using `browserify` to include npm packages.