### PR TITLE
Added error handler in subscribe call

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,14 @@ app.controller("MyCtrl", function($scope, $wamp) {
    function onevent(args) {
       $scope.hello = args[0];
    }
-   $wamp.subscribe('com.myapp.hello', onevent);
+   $wamp.subscribe('com.myapp.hello', onevent).then(
+    function (subscriptionObject) {
+        console.log("Got subscription object : " + subscriptionObject);
+    },
+    function (err) {
+        console.log("Error while subscribing to com.myapp.hello : " + err);
+    }
+   );
 
    // 2) publish an event
    $wamp.publish('com.myapp.hello', ['Hello, world!']);

--- a/src/angular-wamp.js
+++ b/src/angular-wamp.js
@@ -287,6 +287,9 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                             subscription = angular.extend(s, subscription);
                             deferred.resolve(subscription);
                             return s;
+                        },
+                        function (err) {
+                        	deferred.reject(err);
                         }
                     );
                     if (subscribedCallback) {


### PR DESCRIPTION
This changeset has following changes,
1. Added error handler in Subscribe call so that provided error callback will get executed.
2. Updated README.md to show how to use success/error callbacks in Subscribe call.